### PR TITLE
fix(AHWR-251): fix rendering of old world claims

### DIFF
--- a/app/routes/vet-visits.js
+++ b/app/routes/vet-visits.js
@@ -8,6 +8,7 @@ const { latestTermsAndConditionsUri, multiSpecies } = require('../config')
 const { getLatestApplicationsBySbi } = require('../api-requests/application-api')
 const { getClaimsByApplicationReference, isWithinLastTenMonths } = require('../api-requests/claim-api')
 const applicationType = require('../constants/application-type')
+const { claimType } = require('../constants/claim')
 const { userNeedsNotification } = require('./utils/user-needs-notification')
 
 const pageUrl = `/${vetVisits}`
@@ -56,8 +57,8 @@ module.exports = {
                 'data-sort-value': dateOfVisit.getTime()
               }
             },
-            { text: env.render('species.njk', { species: claim.data.typeOfLivestock }) },
-            { text: env.render('claim-type.njk', { claimType: claim.data.claimType }) },
+            { text: env.render('species.njk', { species: claim.data.typeOfLivestock ?? claim.data.whichReview }) },
+            { text: env.render('claim-type.njk', { claimType: claim.data.claimType ?? claimType.review }) },
             { text: claim.reference },
             { html: env.render('tag.njk', { status: claim.statusId }) }
           ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-dashboard",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-dashboard",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-dashboard",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Dashboard service for AHWP service",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-dashboard",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/vet-visits.test.js
+++ b/test/integration/narrow/routes/vet-visits.test.js
@@ -182,8 +182,7 @@ test('get /vet-visits: old world application only', async () => {
     reference: 'AHWR-TEST-OLD1',
     data: {
       visitDate: almostTenMonthsBefore,
-      typeOfLivestock: 'dairy',
-      claimType: 'R'
+      whichReview: 'dairy',
     },
     statusId: '5'
   }]

--- a/test/integration/narrow/routes/vet-visits.test.js
+++ b/test/integration/narrow/routes/vet-visits.test.js
@@ -182,7 +182,7 @@ test('get /vet-visits: old world application only', async () => {
     reference: 'AHWR-TEST-OLD1',
     data: {
       visitDate: almostTenMonthsBefore,
-      whichReview: 'dairy',
+      whichReview: 'dairy'
     },
     statusId: '5'
   }]


### PR DESCRIPTION
Old world applications are filtered out of the claims summary page based on their visit date. So even though old world application/claims are more than 10 months old now, they can still show up if the actual visit date was later.