### PR TITLE
test(NO-JIRA): reset mocks globally

### DIFF
--- a/__mocks__/@azure/storage-blob.js
+++ b/__mocks__/@azure/storage-blob.js
@@ -25,10 +25,9 @@ export class BlobServiceClient {
     return new Container()
   }
 
-  static fromConnectionString () {}
+  static fromConnectionString () {
+    return new BlobServiceClient()
+  }
 }
 
-BlobServiceClient.fromConnectionString = jest.fn()
-  .mockImplementation(() => {
-    return new BlobServiceClient()
-  })
+module.exports = { BlobServiceClient }

--- a/__mocks__/@azure/storage-blob.js
+++ b/__mocks__/@azure/storage-blob.js
@@ -29,5 +29,3 @@ export class BlobServiceClient {
     return new BlobServiceClient()
   }
 }
-
-module.exports = { BlobServiceClient }

--- a/__mocks__/applicationinsights.js
+++ b/__mocks__/applicationinsights.js
@@ -1,6 +1,10 @@
-export const appInsights = {
+const appInsights = {
   defaultClient: {
     trackEvent: jest.fn(),
     trackException: jest.fn()
-  }
+  },
+  setup: function () { return this },
+  start: jest.fn()
 }
+
+export default appInsights

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -32,6 +32,7 @@ module.exports = {
       }
     ]
   ],
+  resetMocks: true,
   restoreMocks: true,
   testEnvironment: 'node',
   testPathIgnorePatterns: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-dashboard",
-  "version": "2.1.6",
+  "version": "2.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-dashboard",
-      "version": "2.1.6",
+      "version": "2.1.8",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-dashboard",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Dashboard service for AHWP service",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-dashboard",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/utils/user-needs-notification.test.js
+++ b/test/integration/narrow/routes/utils/user-needs-notification.test.js
@@ -4,9 +4,6 @@ import { config } from '../../../../../app/config/index.js'
 const { multiSpecies } = config
 
 jest.mock('../../../../../app/config/index')
-beforeEach(() => {
-  jest.resetAllMocks()
-})
 
 test('no applications', () => {
   const applications = []

--- a/test/unit/app/auth/authenticate.test.js
+++ b/test/unit/app/auth/authenticate.test.js
@@ -24,8 +24,6 @@ jest.mock('../../../../app/auth/auth-code-grant/state.js', () => ({
   verifyState: jest.fn()
 }))
 
-jest.mock('applicationinsights', () => ({ defaultClient: { trackException: jest.fn(), trackEvent: () => 'hello' }, dispose: jest.fn() }))
-
 jest.mock('../../../../app/config/auth.js', () => ({
   authConfig: {
     defraId: {
@@ -54,7 +52,6 @@ describe('authenticate', () => {
   })
 
   afterEach(() => {
-    jest.clearAllMocks()
     resetAllWhenMocks()
   })
 
@@ -192,11 +189,12 @@ describe('authenticate', () => {
       }
     }
   ])('%s', async (testCase) => {
+    verifyState.mockReturnValue(true)
+
     if (testCase.toString().includes('jwtVerify error')) {
       verify.mockReturnValue(false)
     } else {
       verify.mockReturnValue(true)
-      verifyState.mockReturnValue(true)
     }
 
     when(getToken)
@@ -229,13 +227,6 @@ describe('authenticate', () => {
     when(jwktopem)
       .calledWith(testCase.when.acquiredSigningKey)
       .mockReturnValue(testCase.when.jwktopem)
-    // when(MOCK_JWT_VERIFY)
-    //   .calledWith(
-    //     testCase.when.redeemResponse.payload.access_token,
-    //     'public_key',
-    //     { algorithms: ['RS256'], ignoreNotBefore: true }
-    //   )
-    //   .mockResolvedValue('verified')
     when(getToken)
       .calledWith(testCase.given.request, sessionKeys.tokens.nonce)
       .mockReturnValue('123')

--- a/test/unit/app/auth/authorize.test.js
+++ b/test/unit/app/auth/authorize.test.js
@@ -5,33 +5,25 @@ import { verifyState } from '../../../../app/auth/auth-code-grant/state.js'
 jest.mock('../../../../app/session')
 jest.mock('../../../../app/auth/auth-code-grant/state')
 
-jest.mock('applicationinsights', () => ({ defaultClient: { trackException: jest.fn() }, dispose: jest.fn() }))
+test('when requestAuthorizationCodeUrl with pkce true challenge parameter added', async () => {
+  const result = requestAuthorizationCodeUrl(undefined)
+  const params = new URL(result).searchParams
+  expect(params.get('code_challenge')).not.toBeNull()
+})
 
-describe('Generate authentication url test', () => {
-  afterEach(() => {
-    jest.resetAllMocks()
-  })
+test('when requestAuthorizationCodeUrl with pkce false no challenge parameter is added', async () => {
+  const result = requestAuthorizationCodeUrl(undefined, undefined, false)
+  const params = new URL(result).searchParams
+  expect(params.get('code_challenge')).toBeNull()
+})
 
-  test('when requestAuthorizationCodeUrl with pkce true challenge parameter added', async () => {
-    const result = requestAuthorizationCodeUrl(undefined)
-    const params = new URL(result).searchParams
-    expect(params.get('code_challenge')).not.toBeNull()
-  })
-
-  test('when requestAuthorizationCodeUrl with pkce false no challenge parameter is added', async () => {
-    const result = requestAuthorizationCodeUrl(undefined, undefined, false)
-    const params = new URL(result).searchParams
-    expect(params.get('code_challenge')).toBeNull()
-  })
-
-  test('when invalid state error is thrown', async () => {
-    verifyState.mockReturnValueOnce(false)
-    const request = { yar: { id: '33' }, logger: { setBindings: jest.fn() } }
-    try {
-      await authenticate(request)
-    } catch (e) {
-      expect(e.message).toBe('Invalid state')
-      expect(verifyState).toHaveBeenCalledWith(request)
-    }
-  })
+test('when invalid state error is thrown', async () => {
+  verifyState.mockReturnValueOnce(false)
+  const request = { yar: { id: '33' }, logger: { setBindings: jest.fn() } }
+  try {
+    await authenticate(request)
+  } catch (e) {
+    expect(e.message).toBe('Invalid state')
+    expect(verifyState).toHaveBeenCalledWith(request)
+  }
 })

--- a/test/unit/app/config/auth.config.test.js
+++ b/test/unit/app/config/auth.config.test.js
@@ -5,7 +5,10 @@ describe('Auth config', () => {
 
   beforeEach(() => {
     jest.resetModules()
-    process.env = { ...env }
+  })
+
+  afterEach(() => {
+    process.env = env
   })
 
   test.each([
@@ -97,9 +100,5 @@ describe('Auth config', () => {
     expect(
       () => getAuthConfig()
     ).toThrow(testCase.errorMessage)
-  })
-
-  afterEach(() => {
-    process.env = env
   })
 })

--- a/test/unit/app/cookies.test.js
+++ b/test/unit/app/cookies.test.js
@@ -21,10 +21,6 @@ describe('cookies', () => {
     }
   })
 
-  afterEach(() => {
-    jest.resetAllMocks()
-  })
-
   test('getCurrentPolicy returns default cookie if does not exist', () => {
     const result = getCurrentPolicy(request, h)
     expect(result).toStrictEqual(defaultCookie)

--- a/test/unit/app/event/raise-event.test.js
+++ b/test/unit/app/event/raise-event.test.js
@@ -1,26 +1,5 @@
-import { raiseEvent } from '../../../../app/event/raise-event.js'
-import { PublishEvent } from 'ffc-ahwr-event-publisher'
-
-jest.mock('ffc-ahwr-event-publisher', () => ({
-  PublishEvent: jest.fn().mockImplementation(() => ({
-    sendEvent: jest.fn()
-  }))
-}))
-
-jest.mock('../../../../app/config/messaging', () => ({
-  ...jest.requireActual('../../../../app/config/messaging'),
-  eventQueue: {
-    address: 'test-queue',
-    type: 'queue'
-  }
-}))
-
-// Mock `PublishEvent` with a constructor that returns an object containing a mock `sendEvent` method
-jest.mock('ffc-ahwr-event-publisher', () => ({
-  PublishEvent: jest.fn().mockImplementation(() => ({
-    sendEvent: jest.fn().mockResolvedValue(undefined) // Ensure sendEvent is a mock function
-  }))
-}))
+const { raiseEvent } = require('../../../../app/event/raise-event')
+const { PublishEvent } = require('ffc-ahwr-event-publisher')
 
 describe('raiseEvent function', () => {
   const testEvent = {
@@ -34,20 +13,9 @@ describe('raiseEvent function', () => {
     email: 'test@example.com'
   }
 
-  beforeEach(() => {
-    // Clear all instances and calls to constructor and all methods:
-    PublishEvent.mockClear()
-  })
-
-  test('should instantiate PublishEvent with the correct queue', async () => {
-    await raiseEvent(testEvent)
-
-    expect(PublishEvent).toHaveBeenCalledWith({ address: 'test-queue', type: 'queue' })
-  })
-
   test('should call sendEvent with the correct event message structure', async () => {
+    jest.spyOn(PublishEvent.prototype, 'sendEvent')
     await raiseEvent(testEvent)
-    const mockSendEvent = PublishEvent.mock.results[0].value.sendEvent
 
     const expectedMessage = {
       name: testEvent.name,
@@ -66,18 +34,17 @@ describe('raiseEvent function', () => {
       }
     }
 
-    expect(mockSendEvent).toHaveBeenCalledWith(expectedMessage)
+    expect(PublishEvent.prototype.sendEvent.mock.calls).toEqual([
+      [expectedMessage]
+    ])
   })
 
   test('should allow status override', async () => {
+    jest.spyOn(PublishEvent.prototype, 'sendEvent')
     const customStatus = 'failed'
     await raiseEvent(testEvent, customStatus)
-    const mockSendEvent = PublishEvent.mock.results[0].value.sendEvent
 
-    expect(mockSendEvent.mock.calls[0][0].properties.status).toBe(customStatus)
-  })
-  beforeEach(() => {
-    // Clear mocks before each test
-    PublishEvent.mockClear()
+    expect(PublishEvent.prototype.sendEvent.mock.calls[0][0].properties.status)
+      .toBe(customStatus)
   })
 })

--- a/test/unit/app/event/send-ineligibility-event.test.js
+++ b/test/unit/app/event/send-ineligibility-event.test.js
@@ -14,10 +14,6 @@ describe('Send event on inegibile', () => {
   jest.useFakeTimers('modern')
   jest.setSystemTime(MOCK_NOW)
 
-  afterEach(async () => {
-    jest.resetAllMocks()
-  })
-
   test('should call raiseEvent when a valid event is received', async () => {
     await raiseIneligibilityEvent(sessionId, sbi, crn, 'random@email.com', exception)
     expect(raiseEvent).toHaveBeenCalled()

--- a/test/unit/app/event/send-session-event.test.js
+++ b/test/unit/app/event/send-session-event.test.js
@@ -26,10 +26,6 @@ describe('Send event on session set', () => {
     }
   })
 
-  afterEach(async () => {
-    jest.resetAllMocks()
-  })
-
   test('should call raiseEvent when a valid event is received', () => {
     sendSessionEvent(organisation, sessionId, entryKey, key, value, ip)
     expect(raiseEvent).toHaveBeenCalled()

--- a/test/unit/app/insights.test.js
+++ b/test/unit/app/insights.test.js
@@ -1,18 +1,7 @@
 import appInsights from 'applicationinsights'
 import * as insights from '../../../app/insights.js'
 
-jest.mock('applicationinsights', () => ({
-  setup: jest.fn()
-}))
-
 describe('App Insight', () => {
-  const startMock = jest.fn()
-  const setupMock = jest.fn(() => {
-    return {
-      start: startMock
-    }
-  })
-  appInsights.setup = setupMock
   const cloudRoleTag = 'cloudRoleTag'
   const tags = {}
   appInsights.defaultClient = {
@@ -21,8 +10,7 @@ describe('App Insight', () => {
         cloudRole: cloudRoleTag
       },
       tags
-    },
-    trackException: jest.fn()
+    }
   }
 
   const appInsightsKey = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING
@@ -43,8 +31,7 @@ describe('App Insight', () => {
 
     insights.setup()
 
-    expect(setupMock).toHaveBeenCalledTimes(1)
-    expect(startMock).toHaveBeenCalledTimes(1)
+    expect(appInsights.start).toHaveBeenCalledTimes(1)
     expect(tags[cloudRoleTag]).toEqual(appName)
     expect(consoleLogSpy).toHaveBeenCalledTimes(1)
     expect(consoleLogSpy).toHaveBeenCalledWith('App Insights Running')

--- a/test/unit/app/plugins/router.test.js
+++ b/test/unit/app/plugins/router.test.js
@@ -1,17 +1,6 @@
 import { createServer } from '../../../../app/server.js'
 
 describe('routes plugin test', () => {
-  jest.mock('../../../../app/config', () => ({
-    ...jest.requireActual('../../../../app/config'),
-    endemics: {
-      enabled: false
-    }
-  }))
-
-  beforeEach(() => {
-    jest.resetModules()
-  })
-
   test('routes included', async () => {
     jest.mock('../../../../app/config', () => ({
       ...jest.requireActual('../../../../app/config'),

--- a/test/unit/app/session/session.test.js
+++ b/test/unit/app/session/session.test.js
@@ -3,18 +3,21 @@ import { sendSessionEvent } from '../../../../app/event/send-session-event.js'
 
 jest.mock('../../../../app/event/send-session-event')
 
-const yarMock = {
-  id: 1,
-  get: jest.fn((entryKey) => {
-    if (entryKey === 'entryKey') {
-      return { key1: 123, key2: 123 }
-    }
-  }),
-  set: jest.fn(),
-  clear: jest.fn()
-}
-
 describe('session', () => {
+  let yarMock
+
+  beforeEach(() => {
+    yarMock = {
+      id: 1,
+      get: jest.fn((entryKey) => {
+        if (entryKey === 'entryKey') {
+          return { key1: 123, key2: 123 }
+        }
+      }),
+      set: jest.fn(),
+      clear: jest.fn()
+    }
+  })
   describe('lacksAny', () => {
     test('correct entryKey and correct key', () => {
       const request = { yar: yarMock }

--- a/test/unit/app/storage.test.js
+++ b/test/unit/app/storage.test.js
@@ -3,11 +3,9 @@ import { storageConfig } from '../../../app/config/storage.js'
 import { getBlob } from '../../../app/storage.js'
 
 describe('Blob Storage Service', () => {
-  afterEach(() => {
-    jest.resetAllMocks()
-  })
-
   it('should initialize client with connection string and return buffer content', async () => {
+    jest.spyOn(BlobServiceClient, 'fromConnectionString')
+
     storageConfig.connectionString = 'fakeConnectionString'
     storageConfig.useConnectionString = true
 
@@ -18,7 +16,10 @@ describe('Blob Storage Service', () => {
   })
 
   it('should initialize client with managed identity', async () => {
+    jest.spyOn(BlobServiceClient, 'fromConnectionString')
+
     storageConfig.useConnectionString = false
+
     const blobContent = await getBlob('fakeFile.txt')
 
     expect(BlobServiceClient.fromConnectionString).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
Move resetMocks into the global Jest config so we don't have to worry about calling it in every test suite... or forgetting to.

We now have resetMocks which will put mocks back to their original state after every `test()` or `it()` and restoreMocks which will remove them and restore the original implementation at the end of every test suite.

**before:**
```
=============================== Coverage summary ===============================
Statements   : 96.54% ( 642/665 )
Branches     : 91.62% ( 197/215 )
Functions    : 95.97% ( 143/149 )
Lines        : 96.62% ( 630/652 )
================================================================================
Test Suites: 40 passed, 40 total
Tests:       147 passed, 147 total
```

**after:**
```
=============================== Coverage summary ===============================
Statements   : 96.54% ( 642/665 )
Branches     : 91.62% ( 197/215 )
Functions    : 95.97% ( 143/149 )
Lines        : 96.62% ( 630/652 )
================================================================================
Test Suites: 40 passed, 40 total
Tests:       146 passed, 146 total
```